### PR TITLE
Add "ZZ ZZ" method to Units so it doesn't conflict w/ Brackets

### DIFF
--- a/M2/Macaulay2/packages/Units.m2
+++ b/M2/Macaulay2/packages/Units.m2
@@ -56,7 +56,7 @@ Measurement ^ ZZ := (m,i) -> if i === 0 then 1 else new Measurement from {m#0^i,
 Measurement + Measurement := (m,n) -> ( if m#1 =!= n#1 then error "sum: incompatible measurements"; new Measurement from { m#0 + n#0 , m#1 } )
 Measurement - Measurement := (m,n) -> m + -n
 
-Constant Number := Number Constant := Number Number := times
+Constant Number := Number Constant := Number Number := ZZ ZZ := times
 
 exa = 10^18
 peta = 10^15


### PR DESCRIPTION
If we loaded Brackets before Units, then the definition of "circle" gave us an error because "radian 2" gave us [1, 2] instead of 1 * 2.

<!--
Thank you for contributing to Macaulay2!

Please read https://github.com/Macaulay2/M2/wiki/Pull-requests for instructions.
-->
